### PR TITLE
Refactor command parsing logic using Streams and Map

### DIFF
--- a/src/main/java/shrimp/utility/Parser.java
+++ b/src/main/java/shrimp/utility/Parser.java
@@ -3,6 +3,7 @@ package shrimp.utility;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeFormatterBuilder;
 import java.time.temporal.ChronoField;
+import java.util.Map;
 
 /**
  * The {@code Parser} class provides methods to parse user commands and format date-time strings.
@@ -45,28 +46,24 @@ public class Parser {
      */
     public static CommandType parseCommand(String userInput) {
         assert userInput != null : "userInput is null";
-        if (userInput.equalsIgnoreCase("bye")) {
-            return CommandType.BYE;
-        } else if (userInput.equalsIgnoreCase("list")) {
-            return CommandType.LIST;
-        } else if (userInput.startsWith("mark")) {
-            return CommandType.MARK;
-        } else if (userInput.startsWith("unmark")) {
-            return CommandType.UNMARK;
-        } else if (userInput.startsWith("deadline")) {
-            return CommandType.DEADLINE;
-        } else if (userInput.startsWith("event")) {
-            return CommandType.EVENT;
-        } else if (userInput.startsWith("todo")) {
-            return CommandType.ADD;
-        } else if (userInput.startsWith("delete")) {
-            return CommandType.DELETE;
-        } else if (userInput.startsWith("clear")) {
-            return CommandType.CLEAR;
-        } else if (userInput.startsWith("find")) {
-            return CommandType.FIND;
-        } else {
-            return CommandType.ERROR;
-        }
+        Map<String, CommandType> commandTypeMap = Map.of(
+                "bye", CommandType.BYE,
+                "list", CommandType.LIST,
+                "mark", CommandType.MARK,
+                "unmark", CommandType.UNMARK,
+                "deadline", CommandType.DEADLINE,
+                "event", CommandType.EVENT,
+                "todo", CommandType.ADD,
+                "delete", CommandType.DELETE,
+                "clear", CommandType.CLEAR,
+                "find", CommandType.FIND
+        );
+
+        // Loop through map entries and check if the userInput starts with any key
+        return commandTypeMap.entrySet().stream()
+                .filter(entry -> userInput.startsWith(entry.getKey()))
+                .map(Map.Entry::getValue)
+                .findFirst()
+                .orElse(CommandType.ERROR);
     }
 }


### PR DESCRIPTION
Refactored the `Parser.parseCommand()` method to improve efficiency and readability by replacing the if-else chain with a Map. The map is used to store command keywords and their corresponding CommandType, allowing for a more concise and scalable approach.

Additionally, streams are used to handle the parsing logic, enhancing the overall maintainability and reducing the risk of errors. This change improves code quality by reducing the cognitive load when understanding and extending the command parsing logic.

These changes adhere to best practices for code readability, performance, and scalability.
